### PR TITLE
Fix dealer blackjack message flash and bump to v0.35.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackjacktrainer/blackjack-simulator",
-  "version": "0.35.9",
+  "version": "0.35.10",
   "engines": {
     "node": ">=20"
   },

--- a/src/game.ts
+++ b/src/game.ts
@@ -334,13 +334,16 @@ export default class Game extends EventEmitter<EventMap> {
           }
 
           this.askInsurance(input, this.player, ...this.playersLeft);
-          this.payoutInsurance(input);
 
           if (this.dealer.holeCard.value === 10) {
+            // Flip hole card before payout so the dealer's blackjack state
+            // is set when setHandWinner emits the change event.
             this.dealer.firstHand.incrementTotalsForCard(this.dealer.cards[0]);
             this.dealer.cards[0].flip();
+            this.payoutInsurance(input);
             step = GameStep.WaitingForNewGameInput;
           } else {
+            this.payoutInsurance(input);
             step = GameStep.PlayHandsRight;
           }
 

--- a/test/src/game.ts
+++ b/test/src/game.ts
@@ -740,6 +740,47 @@ describe('Game', function () {
       },
     );
 
+    context(
+      'when dealer has blackjack with ace up, dealer.blackjack should be true when handWinner emits',
+      function () {
+        let dealerBlackjackAtEmit: boolean;
+
+        before(function () {
+          dealerBlackjackAtEmit = false;
+
+          game = setupGame({
+            settings: {
+              autoDeclineInsurance: false,
+            },
+            dealerCards: [Rank.Ace, Rank.Ten],
+            playerCards: [Rank.Five, Rank.Five],
+          });
+
+          game.on(Event.Change, (name: unknown, value: unknown) => {
+            if (
+              name === 'player' &&
+              isPlayerAttributes(value) &&
+              value.handWinner[value.hands[0].id] === 'dealer'
+            ) {
+              // Capture dealer blackjack state at the moment handWinner is emitted.
+              dealerBlackjackAtEmit = game.dealer.firstHand.blackjack;
+            }
+          });
+
+          game.step();
+          game.step(Move.NoInsurance);
+        });
+
+        after(function () {
+          game.removeAllListeners(Event.Change);
+        });
+
+        it('should have dealer.blackjack true when handWinner change fires', function () {
+          expect(dealerBlackjackAtEmit).to.be.true;
+        });
+      },
+    );
+
     context('when the player splits aces without more aces', function () {
       before(function () {
         game = setupGame({


### PR DESCRIPTION
## Summary
When dealer had blackjack with Ace up, `payoutInsurance` called `setHandWinner(Dealer)` before the hole card was flipped. The UI briefly showed "Dealer wins" then flashed to "Dealer wins (blackjack)" once the flip event arrived.

Fix: move `incrementTotalsForCard` + `flip()` before `payoutInsurance` so the dealer's blackjack state is already set when the hand winner change event emits.

Includes version bump to 0.35.10.

## Test plan
- [x] Test: `dealer.blackjack` is true at the moment `handWinner` change fires (was failing, now passes)
- [x] All 94 tests pass
- [x] Lint passes