### PR TITLE
Fix stale basic strategy chart cache when settings change

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackjacktrainer/blackjack-simulator",
-  "version": "0.35.10",
+  "version": "0.35.11",
   "engines": {
     "node": ">=20"
   },

--- a/src/basic-strategy-checker.ts
+++ b/src/basic-strategy-checker.ts
@@ -22,7 +22,39 @@ function chartMinMax(chartType: ChartType): [number, number] {
   return CHART_MIN_MAX[chartType];
 }
 
-let cachedSubCharts: Record<ChartType, ChartMove[][]> | undefined;
+type SubCharts = Record<ChartType, ChartMove[][]>;
+
+let cachedSubCharts: SubCharts | undefined;
+let cachedCacheKey: string | undefined;
+
+function chartCacheKey(settings: GameSettings): string {
+  return `${settings.deckCount}:${settings.hitSoft17}`;
+}
+
+function getSubCharts(settings: GameSettings): SubCharts {
+  const key = chartCacheKey(settings);
+  if (cachedSubCharts !== undefined && cachedCacheKey === key) {
+    return cachedSubCharts;
+  }
+
+  const { chart: chartGroup } = selectCharts(settings);
+  const hard = chartGroup.get(ChartType.Hard);
+  const soft = chartGroup.get(ChartType.Soft);
+  const splits = chartGroup.get(ChartType.Splits);
+
+  if (!hard || !soft || !splits) {
+    throw new Error('Subchart not found');
+  }
+
+  cachedSubCharts = {
+    [ChartType.Hard]: hard,
+    [ChartType.Soft]: soft,
+    [ChartType.Splits]: splits,
+  };
+  cachedCacheKey = key;
+
+  return cachedSubCharts;
+}
 
 export default class BasicStrategyChecker {
   static uncommonHands(settings: GameSettings): UncommonChart {
@@ -34,23 +66,7 @@ export default class BasicStrategyChecker {
       return Move.NoInsurance;
     }
 
-    if (!cachedSubCharts) {
-      const { chart: chartGroup } = selectCharts(gameSettings);
-      const hard = chartGroup.get(ChartType.Hard);
-      const soft = chartGroup.get(ChartType.Soft);
-      const splits = chartGroup.get(ChartType.Splits);
-
-      if (!hard || !soft || !splits) {
-        throw new Error('Subchart not found');
-      }
-
-      cachedSubCharts = {
-        [ChartType.Hard]: hard,
-        [ChartType.Soft]: soft,
-        [ChartType.Splits]: splits,
-      };
-    }
-
+    const subCharts = getSubCharts(gameSettings);
     const chartType = this._chartType(hand);
     const [chartMin, chartMax] = chartMinMax(chartType);
 
@@ -60,7 +76,7 @@ export default class BasicStrategyChecker {
       chartMax,
     );
 
-    const chart = cachedSubCharts[chartType];
+    const chart = subCharts[chartType];
 
     const dealerHints = chart[playerTotal - chartMin];
     const dealersCard = game.dealer.upcard.value;

--- a/test/src/game.ts
+++ b/test/src/game.ts
@@ -1476,6 +1476,36 @@ describe('Game', function () {
       });
     });
 
+    context(
+      'when switching from 2-deck to 6-deck, 6,6 vs 7 should change from split to hit',
+      function () {
+        before(function () {
+          // First game: 2-deck. 6,6 vs 7 with DAS = Split (Ph).
+          game = setupGame({
+            settings: { deckCount: 2, hitSoft17: true },
+            dealerCards: [Rank.Seven],
+            playerCards: [Rank.Six, Rank.Six],
+          });
+          dealToPlayInput(game);
+          game.step(Move.Split);
+          expect(game.state.sessionMovesCorrect).to.equal(1);
+        });
+
+        it('should suggest hit for 6,6 vs 7 in 6-deck', function () {
+          // Second game: 6-deck. 6,6 vs 7 = Hit.
+          game = setupGame({
+            settings: { deckCount: 6, hitSoft17: true },
+            dealerCards: [Rank.Seven],
+            playerCards: [Rank.Six, Rank.Six],
+          });
+          dealToPlayInput(game);
+          game.step(Move.Hit);
+          expect(game.state.sessionMovesCorrect).to.equal(1);
+          expect(game.state.playCorrection).to.equal('');
+        });
+      },
+    );
+
     context('when an NPC splits aces and receives non-ace cards', function () {
       let npcPlayer: InstanceType<typeof Game>['players'][number];
 


### PR DESCRIPTION
## Summary
The `BasicStrategyChecker` cached chart lookups in a module-level variable that was never invalidated. When a user changed deck count (e.g., 2-deck default to 6-deck), the old chart was still used.

This caused 6,6 vs 7 to incorrectly suggest Split (correct in 2-deck with DAS) instead of Hit (correct in 6-deck).

Fix: key the cache on `deckCount` and `hitSoft17` so it self-invalidates when either setting changes. The simulator still benefits from caching since settings don't change between hands.

## Test plan
- [x] Test: create 2-deck game (split 6,6v7 = correct), then 6-deck game (hit 6,6v7 = correct). Was failing, now passes.
- [x] All 95 tests pass
- [x] Lint passes