### PR TITLE
Fix insurance deviation not firing with soft hands

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackjacktrainer/blackjack-simulator",
-  "version": "0.35.11",
+  "version": "0.35.12",
   "engines": {
     "node": ">=20"
   },

--- a/src/hi-lo-deviation-checker.ts
+++ b/src/hi-lo-deviation-checker.ts
@@ -92,14 +92,19 @@ export default class HiLoDeviationChecker {
   ): Deviation | undefined {
     const trueCount = game.shoe.hiLoTrueCount;
 
-    if (game.dealer.upcard == null || hand.isSoft) {
+    if (game.dealer.upcard == null) {
       return;
     }
 
-    const playerTotal =
-      game.state.step === GameStep.WaitingForInsuranceInput
-        ? 0
-        : hand.cardTotal;
+    const isInsurance = game.state.step === GameStep.WaitingForInsuranceInput;
+
+    // Soft hands have no play deviations in the I18, but insurance is
+    // independent of the player's hand.
+    if (hand.isSoft && !isInsurance) {
+      return;
+    }
+
+    const playerTotal = isInsurance ? 0 : hand.cardTotal;
     const dealersCard = game.dealer.upcard.value;
 
     const deviation =

--- a/test/src/game.ts
+++ b/test/src/game.ts
@@ -640,6 +640,34 @@ describe('Game', function () {
     );
 
     context(
+      'when player accepts insurance at TC >= 3 with a soft hand',
+      function () {
+        before(function () {
+          game = setupGame({
+            settings: {
+              deckCount: 6,
+              autoDeclineInsurance: false,
+              checkDeviations: true,
+            },
+            dealerCards: [Rank.Ace, Rank.Nine],
+            playerCards: [Rank.Ace, Rank.Two],
+          });
+
+          game.step();
+          game.shoe.hiLoRunningCount = game.shoe.decksRemaining * 3.89;
+
+          game.step(Move.AskInsurance);
+        });
+
+        it('should mark insurance as correct (soft hand should not block insurance deviation)', function () {
+          expect(game.state.sessionMovesCorrect).to.equal(1);
+          expect(game.state.sessionMovesTotal).to.equal(1);
+          expect(game.state.playCorrection).to.equal('');
+        });
+      },
+    );
+
+    context(
       'when player correctly declines insurance at TC < 3 with checkDeviations on',
       function () {
         before(function () {


### PR DESCRIPTION
## Summary
The `_suggest` method returned early for soft hands, which is correct for play deviations (no I18 entries for soft totals) but wrong for insurance. Insurance is independent of the player's hand. A player with A+2 (soft 13) at TC >= 3 was incorrectly told not to buy insurance.

Fix: skip the soft-hand check when the step is `WaitingForInsuranceInput`.

Bump version to 0.35.12.

## Test plan
- [x] Test: accept insurance at TC >= 3 with soft hand (A+2) -> marked correct (was failing, now passes)
- [x] All 96 tests pass
- [x] Lint passes

Reported by user: "I bought insurance at TC >= 3 but got an error saying to not buy insurance if TC is < 3"