### PR TITLE
Fix 9 vs 2 deviation incorrectly flagging double as wrong

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackjacktrainer/blackjack-simulator",
-  "version": "0.35.12",
+  "version": "0.35.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackjacktrainer/blackjack-simulator",
-  "version": "0.35.12",
+  "version": "0.35.13",
   "engines": {
     "node": ">=20"
   },

--- a/src/hi-lo-deviation-checker.ts
+++ b/src/hi-lo-deviation-checker.ts
@@ -21,7 +21,7 @@ export const illustrious18Deviations: Deviations = new Map<playerTotal, Map<deal
   ]),
   ],
   [9,  new Map([
-    [2,  { correctMove: Move.Hit,    index: ['<',   1] }],
+    [2,  { correctMove: Move.Double, index: ['>=',  1] }],
     [7,  { correctMove: Move.Double, index: ['>=',  3] }],
   ]),
   ],

--- a/test/src/game.ts
+++ b/test/src/game.ts
@@ -1046,7 +1046,7 @@ describe('Game', function () {
       });
     });
 
-    context('I18 9v2: at TC = 0.5, hit deviation should fire', function () {
+    context('I18 9v2: at TC = 0.5, no deviation should fire', function () {
       let result: CheckDeviationResult | undefined;
       before(function () {
         game = setupGame({
@@ -1062,12 +1062,32 @@ describe('Game', function () {
           Move.Double,
         );
       });
-      it('should suggest hit', function () {
-        expect(result).to.be.an('object');
-        expect((result as CheckDeviationResult).result).to.be.false;
-        expect((result as CheckDeviationResult).code).to.equal(Move.Hit);
+      it('should not fire double deviation', function () {
+        expect(result).to.equal(undefined);
       });
     });
+
+    context(
+      'I18 9v2: at TC = 1, hit should trigger double deviation',
+      function () {
+        let result: CheckDeviationResult | undefined;
+        before(function () {
+          game = setupGame({
+            settings: { deckCount: 6, checkDeviations: true },
+            dealerCards: [Rank.Two],
+            playerCards: [Rank.Four, Rank.Five],
+          });
+          dealToPlayInput(game);
+          setTrueCount(game, 1);
+          result = HiLoDeviationChecker.check(game, game.focusedHand, Move.Hit);
+        });
+        it('should suggest double', function () {
+          expect(result).to.be.an('object');
+          expect((result as CheckDeviationResult).result).to.be.false;
+          expect((result as CheckDeviationResult).code).to.equal(Move.Double);
+        });
+      },
+    );
 
     // --- I18: 11 vs A, hit < 1 ---
 


### PR DESCRIPTION
## Summary

- The 9 vs 2 deviation was encoded as `{ correctMove: Hit, index: ['<', 1] }`, which matched when TC < 1 — where Hit is already basic strategy (a no-op check)
- At TC >= 1 (where Double is correct per I18), `_suggest` returned `undefined`, fell back to `BasicStrategyChecker`, and flagged Double as a basic strategy error
- Fixed by encoding as `{ correctMove: Double, index: ['>=', 1] }`, consistent with every other deviation in the table (expressing the action that differs from basic strategy and the TC threshold where it applies)
- Updated the TC = 0.5 test to expect `undefined` from `HiLoDeviationChecker` (BasicStrategyChecker correctly handles that case), and added a test for TC >= 1 with Hit input to verify the double deviation fires
- Bump version to 0.35.13

## Test plan

- [x] Run `npm test` — all 97 tests pass
- [x] Play 9 vs 2 at TC >= 1, double — should not be flagged as wrong
- [x] Play 9 vs 2 at TC < 1, double — should be flagged (basic strategy: hit)
- [x] Play 9 vs 2 at TC >= 1, hit — should be flagged (I18 deviation: double)